### PR TITLE
fix: 一部ページにおける不具合を修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Confit to Calendar",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "学会運営システム「Confit (confit.atlas.jp)」のイベント情報をGoogleカレンダーに追加するのを補助します。",
   "permissions": ["activeTab", "tabs", "scripting"],
   "background": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Confit to Calendar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "学会運営システム「Confit (confit.atlas.jp)」のイベント情報をGoogleカレンダーに追加するのを補助します。",
   "permissions": ["activeTab", "tabs", "scripting"],
   "background": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Confit to Calendar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "学会運営システム「Confit (confit.atlas.jp)」のイベント情報をGoogleカレンダーに追加するのを補助します。",
   "permissions": ["activeTab", "tabs", "scripting"],
   "background": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -42,15 +42,25 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
   setupButton(activeInfo.tabId)
 })
 
+// GETリクエストのパラメータの上限に達しそうであれば短くする
+const shortenDetailsIfTooLong = (details: string) => {
+  // 日本語はエンコーディングでかなり文字数が増えるので控えめに上限設定
+  if (details.length >= 1000) {
+    return details.slice(0, 1000) + "..."
+  }
+  return details
+}
+
 // messageでイベント情報が送られてきたらタブを開く
 chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
-  const details = `${message.url}\n\n${message.title}\n${message.details}`
+  const details = shortenDetailsIfTooLong(message.details)
+  const describe = `${message.url}\n\n${message.title}\n${details}`
   const calendarURL = generateCalendarURL(
     message.title,
     new Date(message.startDate), // stringになっているのでDateにする
     new Date(message.endDate),
     message.location,
-    details,
+    describe,
   )
   // 新しいタブでCalendarの入力画面を開く
   chrome.tabs.create({ url: calendarURL })

--- a/src/background.ts
+++ b/src/background.ts
@@ -42,10 +42,17 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
   setupButton(activeInfo.tabId)
 })
 
+// カレンダーの予定の説明文にConfitのURLを入れたい場合であっても、パラメータつきのURLだと破綻するのでパラメータを除去する
+const removeParams = (url: string) => {
+  const urlObj = new URL(url)
+  urlObj.search = ""
+  return urlObj.toString()
+}
+
 // messageでイベント情報が送られてきたらタブを開く
 chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
-  const details = `${message.url}\n\n${message.title}\n${message.details}`
-  console.log("message:", message)
+  const url = removeParams(message.url)
+  const details = `${url}\n\n${message.title}\n${message.details}`
   const calendarURL = generateCalendarURL(
     message.title,
     new Date(message.startDate), // stringになっているのでDateにする

--- a/src/background.ts
+++ b/src/background.ts
@@ -42,17 +42,9 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
   setupButton(activeInfo.tabId)
 })
 
-// カレンダーの予定の説明文にConfitのURLを入れたい場合であっても、パラメータつきのURLだと破綻するのでパラメータを除去する
-const removeParams = (url: string) => {
-  const urlObj = new URL(url)
-  urlObj.search = ""
-  return urlObj.toString()
-}
-
 // messageでイベント情報が送られてきたらタブを開く
 chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
-  const url = removeParams(message.url)
-  const details = `${url}\n\n${message.title}\n${message.details}`
+  const details = `${message.url}\n\n${message.title}\n${message.details}`
   const calendarURL = generateCalendarURL(
     message.title,
     new Date(message.startDate), // stringになっているのでDateにする


### PR DESCRIPTION
現象：ポスターセッションのページなど、説明文全文を載せると長くなりすぎる場合にカレンダー側がinvalid requestと返してくる

対処：長過ぎる説明文は短くする（約1000文字以下にする→URLエンコーディングで日本語が伸びるので最終的に6000~7000文字くらい）